### PR TITLE
add ipopt for callbacks in problem_solvers

### DIFF
--- a/src/problem_solvers.jl
+++ b/src/problem_solvers.jl
@@ -7,6 +7,7 @@ using ..SaveLoadUtils
 using NamedTrajectories
 using QuantumCollocationCore
 using MathOptInterface
+using Ipopt
 using TestItems
 const MOI = MathOptInterface
 


### PR DESCRIPTION
When fixing bugs in the merge after the core peeloff (see https://github.com/kestrelquantum/QuantumCollocation.jl/pull/173), we moved Ipopt to be a dependency only in the core. Thus we need to add a using