### PR TITLE
add ipopt for callbacks in problem_solvers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "QuantumCollocationCore"
 uuid = "2b384925-53cb-4042-a8d2-6faa627467e1"
 authors = ["Aaron Trowbridge <aaron.j.trowbridge@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Einsum = "b7d42ee7-0b51-5a75-98ca-779d3107e4c0"

--- a/src/problem_solvers.jl
+++ b/src/problem_solvers.jl
@@ -7,6 +7,7 @@ using ..SaveLoadUtils
 using NamedTrajectories
 using QuantumCollocationCore
 using MathOptInterface
+using Ipopt
 using TestItems
 const MOI = MathOptInterface
 


### PR DESCRIPTION
add Ipopt using as dependency tree changed when core was peeled off of frontend (see https://github.com/kestrelquantum/QuantumCollocation.jl/pull/173). 